### PR TITLE
Use fixed date and date-time values in generated response examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.2.11 (Jan 11, 2024)
+
+High level enhancements
+
+- hardcoded the date in response examples to prevent unwanted diffs
+
 ## 1.2.10 (Oct 19, 2023)
 
 High level enhancements

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.2.10",
+  "version": "1.2.11",
   "npmClient": "yarn",
   "useWorkspaces": true
 }

--- a/packages/docusaurus-plugin-openapi-docs/package.json
+++ b/packages/docusaurus-plugin-openapi-docs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@slashid/docusaurus-plugin-openapi-docs-slashid",
   "description": "OpenAPI plugin for Docusaurus.",
-  "version": "1.2.10",
+  "version": "1.2.11",
   "license": "MIT",
   "keywords": [
     "openapi",

--- a/packages/docusaurus-plugin-openapi-docs/src/openapi/createResponseExample.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/openapi/createResponseExample.ts
@@ -29,8 +29,8 @@ const primitives: Primitives = {
   string: {
     default: () => "string",
     email: () => "user@example.com",
-    date: () => new Date().toISOString().substring(0, 10),
-    "date-time": () => new Date().toISOString().substring(0, 10),
+    date: () => "2005-12-24",
+    "date-time": () => "2005-12-24T18:29:30.033157Z",
     uuid: () => "3fa85f64-5717-4562-b3fc-2c963f66afa6",
     hostname: () => "example.com",
     ipv4: () => "198.51.100.42",


### PR DESCRIPTION
Dear reviewers, please tell me if I'm missing some steps here.

The motivation for the change is twofold:
- the original example for `date-time` is just a date in `YYY-MM-DD` format
- having dynamic values (the date of code generation) end up in MDX files produces unnecessary changes and conflicts