### PR TITLE
Fix OpenAPI description field escaping

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.2.13-rc.0",
+  "version": "1.2.13",
   "npmClient": "yarn",
   "useWorkspaces": true
 }

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.2.13",
+  "version": "1.2.12",
   "npmClient": "yarn",
   "useWorkspaces": true
 }

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.3.0",
+  "version": "1.2.14",
   "npmClient": "yarn",
   "useWorkspaces": true
 }

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.2.13",
+  "version": "1.3.0",
   "npmClient": "yarn",
   "useWorkspaces": true
 }

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.2.12",
+  "version": "1.2.13-rc.0",
   "npmClient": "yarn",
   "useWorkspaces": true
 }

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "release:changelog": "scripts/changelog.ts",
     "release:version": "scripts/version.ts",
     "release:publish": "scripts/publish.ts",
+    "lerna": "lerna",
     "clean": "rm -rf node_modules build demo/.docusaurus demo/build demo/node_modules && find packages -name node_modules -type d -maxdepth 2 -exec rm -rf {} + && find packages -name dist -type d -maxdepth 2 -exec rm -rf {} + && find packages -name lib -type d -maxdepth 2 -exec rm -rf {} + && find packages -name lib-next -type d -maxdepth 2 -exec rm -rf {} +"
   },
   "devDependencies": {

--- a/packages/docusaurus-plugin-openapi-docs/package.json
+++ b/packages/docusaurus-plugin-openapi-docs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@slashid/docusaurus-plugin-openapi-docs-slashid",
   "description": "OpenAPI plugin for Docusaurus.",
-  "version": "1.2.13-rc.0",
+  "version": "1.2.13",
   "license": "MIT",
   "keywords": [
     "openapi",

--- a/packages/docusaurus-plugin-openapi-docs/package.json
+++ b/packages/docusaurus-plugin-openapi-docs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@slashid/docusaurus-plugin-openapi-docs-slashid",
   "description": "OpenAPI plugin for Docusaurus.",
-  "version": "1.3.0",
+  "version": "1.2.14",
   "license": "MIT",
   "keywords": [
     "openapi",

--- a/packages/docusaurus-plugin-openapi-docs/package.json
+++ b/packages/docusaurus-plugin-openapi-docs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@slashid/docusaurus-plugin-openapi-docs-slashid",
   "description": "OpenAPI plugin for Docusaurus.",
-  "version": "1.2.13",
+  "version": "1.3.0",
   "license": "MIT",
   "keywords": [
     "openapi",

--- a/packages/docusaurus-plugin-openapi-docs/package.json
+++ b/packages/docusaurus-plugin-openapi-docs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@slashid/docusaurus-plugin-openapi-docs-slashid",
   "description": "OpenAPI plugin for Docusaurus.",
-  "version": "1.2.12",
+  "version": "1.2.13-rc.0",
   "license": "MIT",
   "keywords": [
     "openapi",

--- a/packages/docusaurus-plugin-openapi-docs/src/markdown/createDescription.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/markdown/createDescription.ts
@@ -5,9 +5,15 @@
  * LICENSE file in the root directory of this source tree.
  * ========================================================================== */
 
+import { codeFence, greaterThan } from "./utils";
+
 export function createDescription(description: string | undefined) {
   if (!description) {
     return "";
   }
-  return `\n\n${description}\n\n`;
+  return `\n\n${description
+    .replace(greaterThan, "\\>")
+    .replace(codeFence, function (match) {
+      return match.replace(/\\>/g, ">");
+    })}\n\n`;
 }

--- a/packages/docusaurus-plugin-openapi-docs/src/markdown/index.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/markdown/index.ts
@@ -7,13 +7,6 @@
 
 import { escape } from "lodash";
 
-import {
-  ContactObject,
-  LicenseObject,
-  MediaTypeObject,
-  SecuritySchemeObject,
-} from "../openapi/types";
-import { ApiPageMetadata, InfoPageMetadata, TagPageMetadata } from "../types";
 import { createAuthentication } from "./createAuthentication";
 import { createContactInfo } from "./createContactInfo";
 import { createDeprecationNotice } from "./createDeprecationNotice";
@@ -26,6 +19,13 @@ import { createStatusCodes } from "./createStatusCodes";
 import { createTermsOfService } from "./createTermsOfService";
 import { createVersionBadge } from "./createVersionBadge";
 import { render } from "./utils";
+import {
+  ContactObject,
+  LicenseObject,
+  MediaTypeObject,
+  SecuritySchemeObject,
+} from "../openapi/types";
+import { ApiPageMetadata, InfoPageMetadata, TagPageMetadata } from "../types";
 
 interface Props {
   title: string;
@@ -60,7 +60,7 @@ export function createApiPageMD({
     `import TabItem from "@theme/TabItem";\n\n`,
     `## ${escape(title)}\n\n`,
     createDeprecationNotice({ deprecated, description: deprecatedDescription }),
-    createDescription(escape(description)),
+    createDescription(description),
     createParamsDetails({ parameters, type: "path" }),
     createParamsDetails({ parameters, type: "query" }),
     createParamsDetails({ parameters, type: "header" }),

--- a/packages/docusaurus-plugin-openapi-docs/src/markdown/utils.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/markdown/utils.ts
@@ -40,3 +40,10 @@ export function render(children: Children): string {
   }
   return children ?? "";
 }
+
+// Regex to selectively URL-encode '>' and '<' chars
+export const lessThan =
+  /<(?!(=|button|\s?\/button|code|\s?\/code|details|\s?\/details|summary|\s?\/summary|hr|\s?\/hr|br|\s?\/br|span|\s?\/span|strong|\s?\/strong|small|\s?\/small|table|\s?\/table|thead|\s?\/thead|tbody|\s?\/tbody|td|\s?\/td|tr|\s?\/tr|th|\s?\/th|h1|\s?\/h1|h2|\s?\/h2|h3|\s?\/h3|h4|\s?\/h4|h5|\s?\/h5|h6|\s?\/h6|title|\s?\/title|p|\s?\/p|em|\s?\/em|b|\s?\/b|i|\s?\/i|u|\s?\/u|strike|\s?\/strike|bold|\s?\/bold|a|\s?\/a|table|\s?\/table|li|\s?\/li|ol|\s?\/ol|ul|\s?\/ul|img|\s?\/img|svg|\s?\/svg|div|\s?\/div|center|\s?\/center))/gu;
+export const greaterThan =
+  /(?<!(button|code|details|summary|hr|br|span|strong|small|table|thead|tbody|td|tr|th|h1|h2|h3|h4|h5|h6|title|p|em|b|i|u|strike|bold|a|li|ol|ul|img|svg|div|center|\/|\s|"|'))>/gu;
+export const codeFence = /`{1,3}[\s\S]*?`{1,3}/g;

--- a/packages/docusaurus-theme-openapi-docs/package.json
+++ b/packages/docusaurus-theme-openapi-docs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@slashid/docusaurus-theme-openapi-docs-slashid",
   "description": "OpenAPI theme for Docusaurus.",
-  "version": "1.2.13-rc.0",
+  "version": "1.2.13",
   "license": "MIT",
   "keywords": [
     "openapi",
@@ -48,7 +48,7 @@
     "@paloaltonetworks/postman-code-generators": "^1.1.12",
     "@paloaltonetworks/postman-collection": "^4.1.0",
     "@reduxjs/toolkit": "^1.7.1",
-    "@slashid/docusaurus-plugin-openapi-docs-slashid": "^1.2.13-rc.0",
+    "@slashid/docusaurus-plugin-openapi-docs-slashid": "^1.2.13",
     "buffer": "^6.0.3",
     "clsx": "^1.1.1",
     "crypto-js": "^4.1.1",

--- a/packages/docusaurus-theme-openapi-docs/package.json
+++ b/packages/docusaurus-theme-openapi-docs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@slashid/docusaurus-theme-openapi-docs-slashid",
   "description": "OpenAPI theme for Docusaurus.",
-  "version": "1.2.13",
+  "version": "1.3.0",
   "license": "MIT",
   "keywords": [
     "openapi",
@@ -48,7 +48,7 @@
     "@paloaltonetworks/postman-code-generators": "^1.1.12",
     "@paloaltonetworks/postman-collection": "^4.1.0",
     "@reduxjs/toolkit": "^1.7.1",
-    "@slashid/docusaurus-plugin-openapi-docs-slashid": "^1.2.13",
+    "@slashid/docusaurus-plugin-openapi-docs-slashid": "^1.3.0",
     "buffer": "^6.0.3",
     "clsx": "^1.1.1",
     "crypto-js": "^4.1.1",

--- a/packages/docusaurus-theme-openapi-docs/package.json
+++ b/packages/docusaurus-theme-openapi-docs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@slashid/docusaurus-theme-openapi-docs-slashid",
   "description": "OpenAPI theme for Docusaurus.",
-  "version": "1.2.13",
+  "version": "1.2.13-rc.0",
   "license": "MIT",
   "keywords": [
     "openapi",
@@ -48,7 +48,7 @@
     "@paloaltonetworks/postman-code-generators": "^1.1.12",
     "@paloaltonetworks/postman-collection": "^4.1.0",
     "@reduxjs/toolkit": "^1.7.1",
-    "@slashid/docusaurus-plugin-openapi-docs-slashid": "^1.2.12",
+    "@slashid/docusaurus-plugin-openapi-docs-slashid": "^1.2.13-rc.0",
     "buffer": "^6.0.3",
     "clsx": "^1.1.1",
     "crypto-js": "^4.1.1",

--- a/packages/docusaurus-theme-openapi-docs/package.json
+++ b/packages/docusaurus-theme-openapi-docs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@slashid/docusaurus-theme-openapi-docs-slashid",
   "description": "OpenAPI theme for Docusaurus.",
-  "version": "1.3.0",
+  "version": "1.2.14",
   "license": "MIT",
   "keywords": [
     "openapi",
@@ -48,7 +48,7 @@
     "@paloaltonetworks/postman-code-generators": "^1.1.12",
     "@paloaltonetworks/postman-collection": "^4.1.0",
     "@reduxjs/toolkit": "^1.7.1",
-    "@slashid/docusaurus-plugin-openapi-docs-slashid": "^1.3.0",
+    "@slashid/docusaurus-plugin-openapi-docs-slashid": "^1.2.14",
     "buffer": "^6.0.3",
     "clsx": "^1.1.1",
     "crypto-js": "^4.1.1",

--- a/scripts/version.ts
+++ b/scripts/version.ts
@@ -71,8 +71,6 @@ function main() {
       nextVersion = v;
   }
 
-  console.log({ nextVersion });
-
   execSync(
     `npm run lerna version ${nextVersion} --no-git-tag-version --no-push --yes` /* ,
     { stdio: "ignore" } */

--- a/scripts/version.ts
+++ b/scripts/version.ts
@@ -71,9 +71,11 @@ function main() {
       nextVersion = v;
   }
 
+  console.log({ nextVersion });
+
   execSync(
-    `lerna version ${nextVersion} --no-git-tag-version --no-push --yes`,
-    { stdio: "ignore" }
+    `npm run lerna version ${nextVersion} --no-git-tag-version --no-push --yes` /* ,
+    { stdio: "ignore" } */
   );
 }
 


### PR DESCRIPTION
Given the difficulty of syncing with upstream, this PR only updates the HTML-escaping logic for the `description` field of the OpenAPI spec. This allows us to embed "```" JSON-like structures into the spec - they will display properly.